### PR TITLE
Add email support to production configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ ARG DJANGO_LOGDIR=/srv/logs/app
 ARG REDIS_CACHE=redis://redis:6379/0
 ARG REDIS_SESSION=redis://redis:6379/1
 ARG DATABASE_URL=postgres://user:password@db:5432/app
+ARG EMAIL_HOST_USER=${EMAIL_HOST_USER}
+ARG EMAIL_POST_PASSWRD=${EMAIL_HOST_PASSWORD}
+ARG EMAIL_HOST=smtp.google.com
 # removable baggage required to build python modules
 ARG DEVLIBS="build-base python3-dev postgresql-dev zlib-dev jpeg-dev openjpeg-dev tiff-dev freetype-dev libffi-dev pcre-dev libressl-dev libwebp-dev lcms2-dev"
 
@@ -23,6 +26,7 @@ ARG DEVLIBS="build-base python3-dev postgresql-dev zlib-dev jpeg-dev openjpeg-de
 
 ENV APP_ROOT=${APP_ROOT} APP_NAME=${APP_NAME} APP_DIR=${APP_DIR} PYTHONUNBUFFERED=1
 ENV DJANGO_MODE=${DJANGO_MODE} DJANGO_ROOT=${APP_ROOT}/${APP_NAME} DJANGO_USER=${DJANGO_USER}
+ENV EMAIL_HOST_USER=${EMAIL_HOST_USER} EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD}
 ENV DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY} DJANGO_LOGDIR=${DJANGO_ROOT}/logs
 ENV REDIS_CACHE=${REDIS_CACHE} REDIS_SESSION=${REDIS_SESSION} DATABASE_URL=${DATABASE_URL}
 

--- a/app/ywfa/settings/base.py
+++ b/app/ywfa/settings/base.py
@@ -165,6 +165,13 @@ MEDIA_URL = '/media/'
 # Wagtail settings
 
 WAGTAIL_SITE_NAME = 'Your Wishes Funeral Advocacy'
+BASE_URL = 'https://yourwishesfuneraladvocacy.com.au'
+WAGTAILIMAGES_MAX_UPLOAD_SIZE = 20 * 1024 * 1024  # i.e. 20MB
+WAGTAILADMIN_NOTIFICATION_FROM_EMAIL = 'webmaster@ywfa.com.au'
+WAGTAILADMIN_NOTIFICATION_USE_HTML = True
+WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS = False
+WAGTAIL_ENABLE_UPDATE_CHECK = True
+WAGTAIL_USAGE_COUNT_ENABLED = True
 
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
@@ -188,8 +195,6 @@ CACHES = {
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 SESSION_CACHE_ALIAS = "default"
-
-BASE_URL = 'https://yourwishesfuneraladvocacy.com.au'
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.0/howto/static-files/

--- a/app/ywfa/settings/production.py
+++ b/app/ywfa/settings/production.py
@@ -23,6 +23,15 @@ sentry_sdk.init(
     send_default_pii=True
 )
 
+env = os.environ
+if env.get('EMAIL_HOST_USER') and env.get('EMAIL_HOST_PASSWORD'):
+    EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+    EMAIL_HOST = env.get('EMAIL_HOST', 'smtp.gmail.com')
+    EMAIL_USE_TLS = env.get('EMAIL_USE_TLS', True) not in (False, 0, '0', 'f', 'F', 'false', 'FALSE', 'off', 'disabled')
+    EMAIL_PORT = env.get('EMAIL_PORT', 587)
+    EMAIL_HOST_USER = env['EMAIL_HOST_USER']
+    EMAIL_HOST_PASSWORD = env['EMAIL_HOST_PASSWORD']
+
 
 try:
     from .local import *

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
         REDIS_CACHE: ${REDIS_CACHE}
         REDIS_SESSION: ${REDIS_SESSION}
         DATABASE_URL: ${DATABASE_URL}
+        EMAIL_HOST_USER: ${EMAIL_HOST_USER}
+        EMAIL_HOST_PASSWORD: ${EMAIL_HOST_PASSWORD}
     volumes:
       - ${PWD}/static:${APP_ROOT}/${APP_NAME}/static
       - ${PWD}/media:${APP_ROOT}/${APP_NAME}/media

--- a/init.sh
+++ b/init.sh
@@ -28,6 +28,8 @@ BASE_URL='http://example.com'
 EXT_ROOT=
 EXT_STATIC=
 EXT_MEDIA=
+EMAIL_HOST_USER=
+EMAIL_HOST_PASSWORD=
 
 # if there i an existing .env, source it to retain values as defaults across sessions
 [ -f ./.env ] && source ./.env
@@ -272,6 +274,8 @@ BASE_URL=${BASE_URL}
 EXT_ROOT=${EXT_ROOT}
 EXT_STATIC=${EXT_STATIC}
 EXT_MEDIA=${EXT_MEDIA}
+EMAIL_HOST_USER=${EMAIL_HOST_USER}
+EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD}
 ENV
 
 echo ""


### PR DESCRIPTION
- note .env is used to pass EMAIL_HOST_USER ans EMAIL_HOST_PASSWORD to container
- both of these values need to be set, there are no defaults
- also added some wagtail directives